### PR TITLE
new version after typer update

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - run: pip install -q poetry
       - run: poetry config virtualenvs.create false --local
       - run: poetry install
-      - run: pip install jeeves-yeti-pyproject
+      - run: pip install jeeves-yeti-pyproject>=0.2.40
       - uses: actions/checkout@v3
         with:
           repository: jeeves-sh/mkdocs-material-insiders

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11']
+        python-version: ['3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/jeeves_shell/cli.py
+++ b/jeeves_shell/cli.py
@@ -17,7 +17,7 @@ def execute_app(typer_app: Jeeves):
     try:
         return typer_app()
 
-    except AssertionError as err:
+    except RuntimeError as err:
         raise NoCommandsFound(directory=Path.cwd()) from err
 
 

--- a/jeeves_shell/discover.py
+++ b/jeeves_shell/discover.py
@@ -28,8 +28,8 @@ def list_installed_plugins() -> PluginsByMountPoint:
         return defaultdict(list)
 
     plugins = [
-        (entry_point.name, entry_point.load())  # type: ignore
-        for entry_point in entry_points(group='jeeves')  # type: ignore
+        (entry_point.name, entry_point.load())
+        for entry_point in entry_points(group='jeeves')
     ]
 
     return funcy.group_values(plugins)

--- a/jeeves_shell/errors.py
+++ b/jeeves_shell/errors.py
@@ -8,7 +8,7 @@ from typer import Typer
 
 
 @dataclass
-class NoCommandsFound(DocumentedError):
+class NoCommandsFound(DocumentedError):   # type: ignore
     """
     No Jeeves commands found, and there is nothing to show.
 
@@ -23,7 +23,7 @@ class NoCommandsFound(DocumentedError):
 
 
 @dataclass
-class PluginConflict(DocumentedError):
+class PluginConflict(DocumentedError):   # type: ignore
     """
     Conflicting plugins detected.
 
@@ -46,7 +46,7 @@ class PluginConflict(DocumentedError):
 
 
 @dataclass
-class UnsuitableRootApp(DocumentedError):
+class UnsuitableRootApp(DocumentedError):   # type: ignore
     """
     Typer app wants to be used as root Jeeves app but it has a callback.
 
@@ -60,7 +60,7 @@ class UnsuitableRootApp(DocumentedError):
 
 
 @dataclass
-class FormattedError(Documented):  # pragma: no cover
+class FormattedError(Documented):    # type: ignore  # pragma: no cover
     """**{self.exception_class}:** {self.message}"""  # noqa: D400
 
     exception: Exception

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "jeeves-shell"
 description = "Pythonic replacement for GNU Make"
-version = "2.3.3"
+version = "2.3.4"
 license = "MIT"
 
 authors = []


### PR DESCRIPTION
# Why

After an upgrade of `typer` dependency (thanks @cfernhout!), we've got some CI issues.

# What

* Make `mypy` happy
* Make sure we do not crash in CI on Python 3.12 due to `flakeheaven` issues (handled by `jeeves-yeti-pyproject` update)
* Bump & release a new version